### PR TITLE
Expand expected AssumeRolePolicy when only one element in array

### DIFF
--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -272,12 +272,13 @@ class Miam::Client
     # Should be able to specify like:
     #   (2) Statement => [ { Principal => AWS => [arn] } ]
     # Actually (1) is reflected when config (2) is applied
-    if expected_assume_role_policy.key?('Statement')
-      expected_assume_role_policy['Statement'].each do |stmt|
-        next unless stmt.key?('Principal')
-        stmt['Principal'].each do |k, v|
-          stmt['Principal'][k] = v[0] if v.is_a?(Array) && v.length < 2
-        end
+    expected_arp_stmt = expected_assume_role_policy.fetch('Statement', [])
+    expected_arp_stmt = expected_arp_stmt.select {|i| i.key?('Principal') }
+
+    expected_arp_stmt.each do |stmt|
+      stmt['Principal'].each do |k, v|
+        entities = Array(v)
+        stmt['Principal'][k] = entities.first if entities.length < 2
       end
     end
 

--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -266,6 +266,21 @@ class Miam::Client
     expected_assume_role_policy.sort_array!
     actual_assume_role_policy.sort_array!
 
+    # With only one entity granted
+    # On IAM
+    #   (1) Statement => [ { Principal => AWS => arn } ]
+    # Should be able to specify like:
+    #   (2) Statement => [ { Principal => AWS => [arn] } ]
+    # Actually (1) is reflected when config (2) is applied
+    if expected_assume_role_policy.key?('Statement')
+      expected_assume_role_policy['Statement'].each do |stmt|
+        next unless stmt.key?('Principal')
+        stmt['Principal'].each do |k, v|
+          stmt['Principal'][k] = v[0] if v.is_a?(Array) && v.length < 2
+        end
+      end
+    end
+
     if expected_assume_role_policy != actual_assume_role_policy
       @driver.update_assume_role_policy(role_name, expected_assume_role_policy, actual_assume_role_policy)
       updated = true


### PR DESCRIPTION
IAM holds the policy in expanded format.

```
Update Role `xxx` > AssumeRolePolicy (dry-run)
 {"Version"=>"2012-10-17",
  "Statement"=>
   [{"Effect"=>"Allow",
-    "Principal"=>{"AWS"=>"arn:aws:iam::NNNNNNNNNNNN:user/Alice"},
+    "Principal"=>
+     {"AWS"=>["arn:aws:iam::NNNNNNNNNNNN:user/Alice"]},
     "Action"=>"sts:AssumeRole"}]} (dry-run)
```
Actually there is no diff.

Placing this code here may be dirty but it was hard to find more appropriate place.