### PR TITLE
Fix bugs for updating managed policies

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ Aws.config.update(
   secret_access_key: ENV['MIAM_TEST_SECRET_ACCESS_KEY'] || 'tiger'
 )
 
-MIAM_TEST_ACCOUNT_ID = Aws::IAM::Client.new.get_user.user.user_id
+MIAM_TEST_ACCOUNT_ID = Aws::STS::Client.new.get_caller_identity.account
 
 RSpec.configure do |config|
   config.before(:each) do


### PR DESCRIPTION
Hi there!

I solved two problems by this branch:

- Some managed policies which has been created by Kinesis Analytics or any AWS services can not be deleted because its path fixed by "/".
  - that policy has the path with "/service-roles/".
- `iam.get_user.user.user_id` returns string like "AIDAxxxx". this is wrong format for ARN.
  - Fix to use `sts:get_caller_identity` API instead.
  - JFYI, there is no need to add permissions to call it.

In my environment, this patch works successfully for deleting managed policy.😇