### PR TITLE
Do not write password to info log

### DIFF
--- a/lib/miam/password_manager.rb
+++ b/lib/miam/password_manager.rb
@@ -13,7 +13,7 @@ class Miam::PasswordManager
 
   def identify(user, type, policy)
     password = mkpasswd(policy)
-    log(:info, "mkpasswd: #{password}")
+    log(:debug, "mkpasswd: #{password}")
     puts_password(user, type, password)
     password
   end


### PR DESCRIPTION
After https://github.com/codenize-tools/miam/pull/22 merged, miam write generated password to info log.

I think it's not secure when running miam on CI server or services. I realized that after update miam gem to use 0.2.4 branch, generate password is show in our CircleCI test result page.

So I want to change this behavior, just logging only debug flag is passed, which this pull request does, or remove password logging as same as current stable version 0.2.3.

What do you think? @winebarrel 

