### PR TITLE
Multiple excludes or targets

### DIFF
--- a/bin/miam
+++ b/bin/miam
@@ -51,8 +51,8 @@ ARGV.options do |opt|
     opt.on(''  , '--split-more')                    {    split                          = :more                                 }
     opt.on('',   '--format=FORMAT', [:ruby, :json]) {|v| format_passed = true; options[:format] = v                             }
     opt.on(''  , '--export-concurrency N', Integer) {|v| options[:export_concurrency]   = v                                     }
-    opt.on(''  , '--target REGEXP')                 {|v| options[:target]               = Regexp.new(v)                         }
-    opt.on(''  , '--exclude REGEXP')                {|v| options[:exclude]              = Regexp.new(v)                         }
+    opt.on(''  , '--target REGEXP')                 {|v| (options[:target] ||= [])     << Regexp.new(v)                         }
+    opt.on(''  , '--exclude REGEXP')                {|v| (options[:exclude] ||= [])    << Regexp.new(v)                         }
     opt.on(''  , '--ignore-login-profile')          {    options[:ignore_login_profile] = true                                  }
     opt.on(''  , '--no-color')                      {    options[:color]                = false                                 }
     opt.on(''  , '--no-progress')                   {    options[:no_progress]          = true                                  }

--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -527,11 +527,11 @@ class Miam::Client
     result = true
 
     if @options[:exclude]
-      result &&= name !~ @options[:exclude]
+      result &&= @options[:exclude].all? {|r| name !~ r}
     end
 
     if @options[:target]
-      result &&= name =~ @options[:target]
+      result &&= @options[:target].any? {|r| name =~ r}
     end
 
     result

--- a/lib/miam/dsl/converter.rb
+++ b/lib/miam/dsl/converter.rb
@@ -196,11 +196,11 @@ end
     result = true
 
     if @options[:exclude]
-      result &&= name !~ @options[:exclude]
+      result &&= @options[:exclude].all? {|r| name !~ r}
     end
 
     if @options[:target]
-      result &&= name =~ @options[:target]
+      result &&= @options[:target].any? {|r| name =~ r}
     end
 
     result

--- a/spec/miam/attach_detach_policy_spec.rb
+++ b/spec/miam/attach_detach_policy_spec.rb
@@ -1,7 +1,7 @@
 describe 'attach/detach policy' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -94,7 +94,7 @@ describe 'attach/detach policy' do
   let(:expected) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>["Admin", "SES"],
          :attached_managed_policies=>[
           "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"],
@@ -174,7 +174,7 @@ describe 'attach/detach policy' do
   context 'when attach policy' do
     let(:update_policy_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -282,7 +282,7 @@ describe 'attach/detach policy' do
   context 'when detach policy' do
     let(:update_policy_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(

--- a/spec/miam/create_spec.rb
+++ b/spec/miam/create_spec.rb
@@ -12,7 +12,7 @@ describe 'create' do
   context 'when create user and group' do
     let(:dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -88,7 +88,7 @@ describe 'create' do
       let(:expected) do
         {:users=>
           {"bob"=>
-            {:path=>"/devloper/",
+            {:path=>"/developer/",
              :groups=>["Admin", "SES"],
              :attached_managed_policies=>[],
              :policies=>
@@ -184,7 +184,7 @@ describe 'create' do
               end
             end
 
-            user "bob", :path=>"/devloper/" do
+            user "bob", :path=>"/developer/" do
               include_template context.user_name
             end
 

--- a/spec/miam/delete_spec.rb
+++ b/spec/miam/delete_spec.rb
@@ -1,7 +1,7 @@
 describe 'delete' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -74,7 +74,7 @@ describe 'delete' do
   let(:expected) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>["Admin", "SES"],
          :attached_managed_policies=>[],
          :policies=>
@@ -139,7 +139,7 @@ describe 'delete' do
   context 'when delete group' do
     let(:delete_group_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -351,7 +351,7 @@ describe 'delete' do
   context 'when delete instance_profile' do
     let(:delete_instance_profiles_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -432,7 +432,7 @@ describe 'delete' do
   context 'when delete role' do
     let(:delete_role_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -491,7 +491,7 @@ describe 'delete' do
   context 'when delete role and instance_profile' do
     let(:delete_role_and_instance_profile_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(

--- a/spec/miam/exclude_spec.rb
+++ b/spec/miam/exclude_spec.rb
@@ -1,7 +1,7 @@
 describe 'target/exclude options' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -177,7 +177,7 @@ describe 'target/exclude options' do
   context 'when exclude a group, a role and an instance profile' do
     let(:exclude_admin_and_my) do
       <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(

--- a/spec/miam/exclude_spec.rb
+++ b/spec/miam/exclude_spec.rb
@@ -1,4 +1,4 @@
-describe 'target/exclude options' do
+describe 'exclude option' do
   let(:dsl) do
     <<-RUBY
       user "bob", :path=>"/developer/" do

--- a/spec/miam/exclude_spec.rb
+++ b/spec/miam/exclude_spec.rb
@@ -1,0 +1,237 @@
+describe 'target/exclude options' do
+  let(:dsl) do
+    <<-RUBY
+      user "bob", :path=>"/devloper/" do
+        login_profile :password_reset_required=>true
+
+        groups(
+          "Admin",
+          "SES"
+        )
+
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      user "mary", :path=>"/staff/" do
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "Admin", :path=>"/admin/" do
+        policy "Admin" do
+          {"Statement"=>[{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "SES", :path=>"/ses/" do
+        policy "ses-policy" do
+          {"Statement"=>
+            [{"Effect"=>"Allow", "Action"=>"ses:SendRawEmail", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      role "my-role", :path=>"/any/" do
+        instance_profiles(
+          "my-instance-profile"
+        )
+
+        assume_role_policy_document do
+          {"Version"=>"2012-10-17",
+           "Statement"=>
+            [{"Sid"=>"",
+              "Effect"=>"Allow",
+              "Principal"=>{"Service"=>"ec2.amazonaws.com"},
+              "Action"=>"sts:AssumeRole"}]}
+        end
+
+        policy "role-policy" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      instance_profile "my-instance-profile", :path=>"/profile/"
+    RUBY
+  end
+
+  before(:each) do
+    apply { dsl }
+  end
+
+  context 'when exclude a user' do
+    let(:exclude_bob) do
+      <<-RUBY
+      user "mary", :path=>"/staff/" do
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "Admin", :path=>"/admin/" do
+        policy "Admin" do
+          {"Statement"=>[{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "SES", :path=>"/ses/" do
+        policy "ses-policy" do
+          {"Statement"=>
+            [{"Effect"=>"Allow", "Action"=>"ses:SendRawEmail", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      role "my-role", :path=>"/any/" do
+        instance_profiles(
+          "my-instance-profile"
+        )
+
+        assume_role_policy_document do
+          {"Version"=>"2012-10-17",
+           "Statement"=>
+            [{"Sid"=>"",
+              "Effect"=>"Allow",
+              "Principal"=>{"Service"=>"ec2.amazonaws.com"},
+              "Action"=>"sts:AssumeRole"}]}
+        end
+
+        policy "role-policy" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      instance_profile "my-instance-profile", :path=>"/profile/"
+      RUBY
+    end
+
+    subject { client(exclude: [/bob/]) }
+
+    it do
+      updated = apply(subject) { exclude_bob }
+      expect(updated).to be_falsey
+    end
+  end
+
+  context 'when exclude a group, a role and an instance profile' do
+    let(:exclude_admin_and_my) do
+      <<-RUBY
+      user "bob", :path=>"/devloper/" do
+        login_profile :password_reset_required=>true
+
+        groups(
+          "Admin",
+          "SES"
+        )
+
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      user "mary", :path=>"/staff/" do
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "SES", :path=>"/ses/" do
+        policy "ses-policy" do
+          {"Statement"=>
+            [{"Effect"=>"Allow", "Action"=>"ses:SendRawEmail", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+      RUBY
+    end
+
+    subject { client(exclude: [/Admin/, /^my-/]) }
+
+    it do
+      updated = apply(subject) { exclude_admin_and_my }
+      expect(updated).to be_falsey
+    end
+  end
+end

--- a/spec/miam/hash_ext_spec.rb
+++ b/spec/miam/hash_ext_spec.rb
@@ -2,7 +2,7 @@ describe 'Hash#sort_array!' do
   let(:hash) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>[],
          :policies=>
           {"S3"=>
@@ -19,7 +19,7 @@ describe 'Hash#sort_array!' do
   let(:expected_hash) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>[],
          :policies=>
           {"S3"=>

--- a/spec/miam/ignore_login_profile_spec.rb
+++ b/spec/miam/ignore_login_profile_spec.rb
@@ -1,7 +1,7 @@
 describe 'ignore login profile' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         policy "S3" do
@@ -18,7 +18,7 @@ describe 'ignore login profile' do
 
   let(:update_dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>false
 
         policy "S3" do
@@ -37,7 +37,7 @@ describe 'ignore login profile' do
   let(:expected) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>[],
          :policies=>
           {"S3"=>

--- a/spec/miam/rename_spec.rb
+++ b/spec/miam/rename_spec.rb
@@ -1,7 +1,7 @@
 describe 'update' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -74,7 +74,7 @@ describe 'update' do
   let(:expected) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>["Admin", "SES"],
          :attached_managed_policies=>[],
          :policies=>
@@ -139,7 +139,7 @@ describe 'update' do
   context 'when rename user' do
     let(:rename_user_dsl) do
       <<-RUBY
-        user "bob2", :path=>"/devloper/", :renamed_from=>"bob" do
+        user "bob2", :path=>"/developer/", :renamed_from=>"bob" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -222,7 +222,7 @@ describe 'update' do
   context 'when rename group' do
     let(:rename_group_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -306,7 +306,7 @@ describe 'update' do
   context 'when rename without renamed_from' do
     let(:rename_without_renamed_from_dsl) do
       <<-RUBY
-        user "bob2", :path=>"/devloper/" do
+        user "bob2", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -391,7 +391,7 @@ describe 'update' do
   context 'when rename role and instance_profile' do
     let(:rename_role_and_instance_profile_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(

--- a/spec/miam/target_spec.rb
+++ b/spec/miam/target_spec.rb
@@ -1,7 +1,7 @@
 describe 'target option' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -98,7 +98,7 @@ describe 'target option' do
   context 'when target a user' do
     let(:target_bob) do
       <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(

--- a/spec/miam/target_spec.rb
+++ b/spec/miam/target_spec.rb
@@ -1,0 +1,185 @@
+describe 'target option' do
+  let(:dsl) do
+    <<-RUBY
+      user "bob", :path=>"/devloper/" do
+        login_profile :password_reset_required=>true
+
+        groups(
+          "Admin",
+          "SES"
+        )
+
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      user "mary", :path=>"/staff/" do
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "Admin", :path=>"/admin/" do
+        policy "Admin" do
+          {"Statement"=>[{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      group "SES", :path=>"/ses/" do
+        policy "ses-policy" do
+          {"Statement"=>
+            [{"Effect"=>"Allow", "Action"=>"ses:SendRawEmail", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      role "my-role", :path=>"/any/" do
+        instance_profiles(
+          "my-instance-profile"
+        )
+
+        assume_role_policy_document do
+          {"Version"=>"2012-10-17",
+           "Statement"=>
+            [{"Sid"=>"",
+              "Effect"=>"Allow",
+              "Principal"=>{"Service"=>"ec2.amazonaws.com"},
+              "Action"=>"sts:AssumeRole"}]}
+        end
+
+        policy "role-policy" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      instance_profile "my-instance-profile", :path=>"/profile/"
+    RUBY
+  end
+
+  before(:each) do
+    apply { dsl }
+  end
+
+  context 'when target a user' do
+    let(:target_bob) do
+      <<-RUBY
+      user "bob", :path=>"/devloper/" do
+        login_profile :password_reset_required=>true
+
+        groups(
+          "Admin",
+          "SES"
+        )
+
+        policy "S3" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+      RUBY
+    end
+
+    subject { client(target: [/bob/]) }
+
+    it do
+      updated = apply(subject) { target_bob }
+      expect(updated).to be_falsey
+    end
+  end
+
+  context 'when target a group, a role and an instance profile' do
+    let(:target_admin_and_my) do
+      <<-RUBY
+      group "Admin", :path=>"/admin/" do
+        policy "Admin" do
+          {"Statement"=>[{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      role "my-role", :path=>"/any/" do
+        instance_profiles(
+          "my-instance-profile"
+        )
+
+        assume_role_policy_document do
+          {"Version"=>"2012-10-17",
+           "Statement"=>
+            [{"Sid"=>"",
+              "Effect"=>"Allow",
+              "Principal"=>{"Service"=>"ec2.amazonaws.com"},
+              "Action"=>"sts:AssumeRole"}]}
+        end
+
+        policy "role-policy" do
+          {"Statement"=>
+            [{"Action"=>
+               ["s3:Get*",
+                "s3:List*"],
+              "Effect"=>"Allow",
+              "Resource"=>"*"}]}
+        end
+
+        attached_managed_policies(
+          "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+        )
+      end
+
+      instance_profile "my-instance-profile", :path=>"/profile/"
+      RUBY
+    end
+
+    subject { client(target: [/Admin/, /^my-/]) }
+
+    it do
+      updated = apply(subject) { target_admin_and_my }
+      expect(updated).to be_falsey
+    end
+  end
+end

--- a/spec/miam/update_spec.rb
+++ b/spec/miam/update_spec.rb
@@ -1,7 +1,7 @@
 describe 'update' do
   let(:dsl) do
     <<-RUBY
-      user "bob", :path=>"/devloper/" do
+      user "bob", :path=>"/developer/" do
         login_profile :password_reset_required=>true
 
         groups(
@@ -74,7 +74,7 @@ describe 'update' do
   let(:expected) do
     {:users=>
       {"bob"=>
-        {:path=>"/devloper/",
+        {:path=>"/developer/",
          :groups=>["Admin", "SES"],
          :attached_managed_policies=>[],
          :policies=>
@@ -149,7 +149,7 @@ describe 'update' do
   context 'when update policy' do
     let(:update_policy_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -236,7 +236,7 @@ describe 'update' do
   context 'when update path' do
     let(:update_path_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -320,7 +320,7 @@ describe 'update' do
   context 'when update path (role, instance_profile)' do
     let(:cannot_update_path_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -409,7 +409,7 @@ describe 'update' do
   context 'when update assume_role_policy' do
     let(:update_assume_role_policy_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -492,7 +492,7 @@ describe 'update' do
   context 'when update groups' do
     let(:update_groups_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -580,7 +580,7 @@ describe 'update' do
   context 'when update login_profile' do
     let(:update_login_profile_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>false
 
           groups(
@@ -663,7 +663,7 @@ describe 'update' do
   context 'when delete login_profile' do
     let(:delete_login_profile_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           groups(
             "Admin",
             "SES"
@@ -744,7 +744,7 @@ describe 'update' do
   context 'when delete policy' do
     let(:delete_policy_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(
@@ -807,7 +807,7 @@ describe 'update' do
   context 'when update instance_profiles' do
     let(:update_instance_profiles_dsl) do
       <<-RUBY
-        user "bob", :path=>"/devloper/" do
+        user "bob", :path=>"/developer/" do
           login_profile :password_reset_required=>true
 
           groups(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,7 +67,7 @@ def tempfile(content, options = {})
 end
 
 def apply(cli = client)
-  tempfile(yield) do |f|
+  result = tempfile(yield) do |f|
     begin
       cli.apply(f.path)
     rescue Aws::IAM::Errors::EntityTemporarilyUnmodifiable, Aws::IAM::Errors::Throttling, Aws::IAM::Errors::NoSuchEntity
@@ -77,6 +77,7 @@ def apply(cli = client)
   end
 
   sleep ENV['APPLY_WAIT'].to_i
+  result
 end
 
 def export(options = {})


### PR DESCRIPTION
This PR makes it possible to specify multiple "target"s and "exclude"s options such as:

```sh
$ bundle exec miam --apply --exclude 'foo' --exclude 'bar' 
```

### Motivation
I want to exclude multiple resources. In order to do so in current version, we have to specify them into one "exclude" option with Regexp such as:

```sh
$ bundle exec miam --apply --exclude '(foo|bar)' 
```
The example is so simple but my actual option is so complicated and hard to read. So I want to separate it with multiple option values.