### PR TITLE
Role MaxSessionDuration support

### DIFF
--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -255,10 +255,22 @@ class Miam::Client
       log(:warn, "Role `#{role_name}`: 'path' cannot be updated", :color => :yellow)
     end
 
-    updated = walk_assume_role_policy(role_name, expected_attrs[:assume_role_policy_document], actual_attrs[:assume_role_policy_document])
+    updated = walk_role_settings(role_name, {max_session_duration: expected_attrs[:max_session_duration]}, {max_session_duration: actual_attrs[:max_session_duration]})
+    updated = walk_assume_role_policy(role_name, expected_attrs[:assume_role_policy_document], actual_attrs[:assume_role_policy_document]) || updated
     updated = walk_role_instance_profiles(role_name, expected_attrs[:instance_profiles], actual_attrs[:instance_profiles]) || updated
     updated = walk_attached_managed_policies(:role, role_name, expected_attrs[:attached_managed_policies], actual_attrs[:attached_managed_policies]) || updated
     walk_policies(:role, role_name, expected_attrs[:policies], actual_attrs[:policies]) || updated
+  end
+
+  def walk_role_settings(role_name, expected_settings, actual_settings)
+    updated = false
+
+    if expected_settings != actual_settings
+      @driver.update_role_settings(role_name, expected_settings, actual_settings)
+      updated = true
+    end
+
+    updated
   end
 
   def walk_assume_role_policy(role_name, expected_assume_role_policy, actual_assume_role_policy)

--- a/lib/miam/driver.rb
+++ b/lib/miam/driver.rb
@@ -178,6 +178,7 @@ class Miam::Driver
       params = {
         :role_name => role_name,
         :assume_role_policy_document => encode_document(assume_role_policy_document),
+        :max_session_duration => attrs.fetch(:max_session_duration)
       }
 
       params[:path] = attrs[:path] if attrs[:path]
@@ -189,6 +190,7 @@ class Miam::Driver
       :assume_role_policy_document => assume_role_policy_document,
       :policies => {},
       :attached_managed_policies => [],
+      :max_session_duration => attrs.fetch(:max_session_duration),
     }
 
     new_role_attrs[:path] = attrs[:path] if attrs[:path]
@@ -234,6 +236,14 @@ class Miam::Driver
       instance_profile_names.each do |instance_profile_name|
         @iam.remove_role_from_instance_profile(:instance_profile_name => instance_profile_name, :role_name => role_name)
       end
+    end
+  end
+
+  def update_role_settings(role_name, new_settings, old_settings)
+    log(:info, "Update Role `#{role_name}` > Settings", :color => :green)
+    log(:info, Miam::Utils.diff(old_settings, new_settings, :color => @options[:color]), :color => false)
+    unless_dry_run do
+      @iam.update_role(new_settings.merge(role_name: role_name))
     end
   end
 

--- a/lib/miam/dsl/context/role.rb
+++ b/lib/miam/dsl/context/role.rb
@@ -4,7 +4,7 @@ class Miam::DSL::Context::Role
   def initialize(context, name, &block)
     @role_name = name
     @context = context.merge(:role_name => name)
-    @result = {:instance_profiles => [], :policies => {}, :attached_managed_policies => []}
+    @result = {:instance_profiles => [], :max_session_duration => 3600, :policies => {}, :attached_managed_policies => []}
     instance_eval(&block)
   end
 
@@ -20,6 +20,10 @@ class Miam::DSL::Context::Role
 
   def instance_profiles(*profiles)
     @result[:instance_profiles].concat(profiles.map(&:to_s))
+  end
+
+  def max_session_duration(duration)
+    @result[:max_session_duration] = duration
   end
 
   def assume_role_policy_document

--- a/lib/miam/dsl/converter.rb
+++ b/lib/miam/dsl/converter.rb
@@ -95,6 +95,8 @@ end
 role #{role_name.inspect}, #{Miam::Utils.unbrace(role_options.inspect)} do
   #{output_role_instance_profiles(attrs[:instance_profiles])}
 
+  #{output_role_max_session_duration(attrs[:max_session_duration])}
+
   #{output_assume_role_policy_document(attrs[:assume_role_policy_document])}
 
   #{output_policies(attrs[:policies])}
@@ -120,6 +122,12 @@ end
       next unless target_matched?(instance_profile_name)
       output_instance_profile(instance_profile_name, attrs)
     }.select {|i| i }.join("\n")
+  end
+
+  def output_role_max_session_duration(max_session_duration)
+    <<-EOS.strip
+      max_session_duration #{max_session_duration}
+    EOS
   end
 
   def output_assume_role_policy_document(assume_role_policy_document)

--- a/lib/miam/exporter.rb
+++ b/lib/miam/exporter.rb
@@ -144,6 +144,8 @@ class Miam::Exporter
       instance_profiles = role.instance_profile_list.map {|i| i.instance_profile_name }
       policies = export_role_policies(role)
       attached_managed_policies = role.attached_managed_policies.map(&:policy_arn)
+      role_data = @iam.get_role(role_name: role_name).role
+      max_session_duration = role_data.max_session_duration
 
       @mutex.synchronize do
         instance_profiles.each do |instance_profile_name|
@@ -159,6 +161,7 @@ class Miam::Exporter
           :instance_profiles => instance_profiles,
           :policies => policies,
           :attached_managed_policies => attached_managed_policies,
+          :max_session_duration => max_session_duration,
         }
 
         progress

--- a/spec/miam/update_spec.rb
+++ b/spec/miam/update_spec.rb
@@ -122,6 +122,7 @@ describe 'update' do
               "Principal"=>{"Service"=>"ec2.amazonaws.com"},
               "Action"=>"sts:AssumeRole"}]},
          :instance_profiles=>["my-instance-profile"],
+         :max_session_duration=>3600,
          :attached_managed_policies=>[],
          :policies=>
           {"role-policy"=>
@@ -885,6 +886,91 @@ describe 'update' do
       expect(updated).to be_truthy
       expected[:roles]["my-role"][:instance_profiles] = ["my-instance-profile2"]
       expected[:instance_profiles]["my-instance-profile2"] = {:path=>"/profile2/"}
+      expect(export).to eq expected
+    end
+  end
+
+  context 'when update role max_session_duration' do
+    let(:update_instance_profiles_dsl) do
+      <<-RUBY
+        user "bob", :path=>"/developer/" do
+          login_profile :password_reset_required=>true
+
+          groups(
+            "Admin",
+            "SES"
+          )
+
+          policy "S3" do
+            {"Statement"=>
+              [{"Action"=>
+                 ["s3:Get*",
+                  "s3:List*"],
+                "Effect"=>"Allow",
+                "Resource"=>"*"}]}
+          end
+        end
+
+        user "mary", :path=>"/staff/" do
+          policy "S3" do
+            {"Statement"=>
+              [{"Action"=>
+                 ["s3:Get*",
+                  "s3:List*"],
+                "Effect"=>"Allow",
+                "Resource"=>"*"}]}
+          end
+        end
+
+        group "Admin", :path=>"/admin/" do
+          policy "Admin" do
+            {"Statement"=>[{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}]}
+          end
+        end
+
+        group "SES", :path=>"/ses/" do
+          policy "ses-policy" do
+            {"Statement"=>
+              [{"Effect"=>"Allow", "Action"=>"ses:SendRawEmail", "Resource"=>"*"}]}
+          end
+        end
+
+        role "my-role", :path=>"/any/" do
+          instance_profiles(
+            "my-instance-profile"
+          )
+
+          max_session_policy 43200
+
+          assume_role_policy_document do
+            {"Version"=>"2012-10-17",
+             "Statement"=>
+              [{"Sid"=>"",
+                "Effect"=>"Allow",
+                "Principal"=>{"Service"=>"ec2.amazonaws.com"},
+                "Action"=>"sts:AssumeRole"}]}
+          end
+
+          policy "role-policy" do
+            {"Statement"=>
+              [{"Action"=>
+                 ["s3:Get*",
+                  "s3:List*"],
+                "Effect"=>"Allow",
+                "Resource"=>"*"}]}
+          end
+        end
+
+        instance_profile "my-instance-profile", :path=>"/profile/"
+      RUBY
+    end
+
+    subject { client }
+
+    it do
+      updated = apply(subject) { update_instance_profiles_dsl }
+      expect(updated).to be_truthy
+      expected[:roles]["my-role"][:max_session_duration] = 43200
       expect(export).to eq expected
     end
   end


### PR DESCRIPTION
https://aws.amazon.com/jp/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/
Federated API token duration can now be configurable upto 12 hrs.
