### PR TITLE
Migrate to aws-sdk v3

### DIFF
--- a/lib/miam.rb
+++ b/lib/miam.rb
@@ -5,7 +5,7 @@ require 'pp'
 require 'singleton'
 require 'thread'
 
-require 'aws-sdk-core'
+require 'aws-sdk-iam'
 Aws.use_bundled_cert!
 
 require 'ruby-progressbar'

--- a/miam.gemspec
+++ b/miam.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-core', '>= 2.0.42', '< 3'
+  spec.add_dependency 'aws-sdk-iam', '~> 1'
   spec.add_dependency 'ruby-progressbar'
   spec.add_dependency 'parallel'
   spec.add_dependency 'term-ansicolor'


### PR DESCRIPTION
Can we migrate aws-sdk version to 3?

(I couldn't find the reason why you fixed the version of aws-sdk to 2.x at https://github.com/codenize-tools/miam/commit/4cdf45ae2e7775c52cfd8febd36cc9dbf96cd3d9 🙌 