### PR TITLE
Implement 'required' method using in template and '--show-backtrace' option

### DIFF
--- a/bin/miam
+++ b/bin/miam
@@ -19,10 +19,11 @@ MAGIC_COMMENT = <<-EOS
 EOS
 
 options = {
-  :dry_run => false,
-  :format  => :ruby,
-  :color   => true,
-  :debug   => false,
+  :dry_run        => false,
+  :format         => :ruby,
+  :color          => true,
+  :debug          => false,
+  :show_backtrace => false
 }
 
 options[:password_manager] = Miam::PasswordManager.new(account_output, options)
@@ -58,6 +59,7 @@ ARGV.options do |opt|
     opt.on(''  , '--no-color')                      {    options[:color]                = false                                 }
     opt.on(''  , '--no-progress')                   {    options[:no_progress]          = true                                  }
     opt.on(''  , '--debug')                         {    options[:debug]                = true                                  }
+    opt.on(''  , '--show-backtrace')                {    options[:show_backtrace]       = true                                  }
     opt.parse!
 
     aws_opts = {}
@@ -186,6 +188,7 @@ rescue => e
     raise e
   else
     $stderr.puts("[ERROR] #{e.message}".red)
+    $stderr.puts(e.backtrace.map(&:yellow)) if options[:show_backtrace]
     exit 1
   end
 end

--- a/lib/miam/template_helper.rb
+++ b/lib/miam/template_helper.rb
@@ -20,9 +20,9 @@ module Miam
     end
 
     def required(*args)
-      missing_args = args.map(&:to_s) - @context.keys
+      missing_args = args.map(&:to_s) - @context.keys.map(&:to_s)
       unless missing_args.empty?
-        ex = ArgumentError.new("Missing arguments: #{missing_args.join(", ")} in '#{@template_name}'")
+        ex = ArgumentError.new("Missing arguments: [#{missing_args.join(", ")}] in template: '#{@template_name}'")
         ex.set_backtrace(@caller)
         raise ex
       end

--- a/lib/miam/template_helper.rb
+++ b/lib/miam/template_helper.rb
@@ -1,6 +1,8 @@
 module Miam
   module TemplateHelper
     def include_template(template_name, context = {})
+      @template_name = template_name
+      @caller = caller[0]
       tmplt = @context.templates[template_name.to_s]
 
       unless tmplt
@@ -15,6 +17,15 @@ module Miam
 
     def context
       @context
+    end
+
+    def required(*args)
+      missing_args = args - @context.keys
+      unless missing_args.empty?
+        ex = ArgumentError.new("Missing arguments: #{missing_args.join(", ")} in '#{@template_name}'")
+        ex.set_backtrace(@caller)
+        raise ex
+      end
     end
   end
 end

--- a/lib/miam/template_helper.rb
+++ b/lib/miam/template_helper.rb
@@ -20,7 +20,7 @@ module Miam
     end
 
     def required(*args)
-      missing_args = args - @context.keys
+      missing_args = args.map(&:to_s) - @context.keys
       unless missing_args.empty?
         ex = ArgumentError.new("Missing arguments: #{missing_args.join(", ")} in '#{@template_name}'")
         ex.set_backtrace(@caller)


### PR DESCRIPTION
Hi,

I often define my templates and check required args are exist like this:

```ruby
template "something" do
  raise ArgumentError.new("Missing args: 'name' in 'something'") if context.name.nil?
  # ...
end
```

I'm feel so redundancy writing in each template definitions, and its error message is unkind for us.
The message only shows below:
```
[ERROR] Missing args: 'name' in 'something'
```
I want to know where this template is called, but it isn't.
So, I implement 'required' method which is be able to use in template block and validates arguments are exists.

In addition, I implement `--show-backtrace` option because to show this message.
When you use both 'required' method and '--show-backtrace' option, miam shows error messages like below: 

![](https://user-images.githubusercontent.com/311408/61872540-911d3180-af1e-11e9-996d-111411b7fa07.png)

