### PR TITLE
Prevent error when use json IAMfile.

### DIFF
--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -61,7 +61,7 @@ class Miam::Client
 
   def walk(file)
     expected = load_file(file)
-    @options[:exclude] += expected[:exclude]
+    @options[:exclude] += expected[:exclude] unless expected[:exclude].nil?
 
     actual, group_users, instance_profile_roles = Miam::Exporter.export(@iam, @options)
     updated = pre_walk_managed_policies(expected[:policies], actual[:policies])


### PR DESCRIPTION
From 0.2.4 (support `exclude` option in ruby DSL) json type IAMfile couldn't works.
Prevent no `exclude` key error to resolve this trouble.