### PR TITLE
Add Accesskey Prohibited User feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ require 'other/iamfile'
 
 user "bob", :path => "/developer/" do
   login_profile :password_reset_required=>true
+  # access_key :access_key_prohibited=>true
 
   groups(
     "Admin"
@@ -113,6 +114,7 @@ end
 
 user "mary", :path => "/staff/" do
   # login_profile :password_reset_required=>true
+  access_key :access_key_prohibited=>false
 
   groups(
     # no group
@@ -192,6 +194,7 @@ end
 ```ruby
 user "bob", :path => "/developer/" do
   login_profile :password_reset_required=>true
+  # access_key :access_key_prohibited=>true
 
   groups(
     "Admin"
@@ -218,6 +221,7 @@ end
 
 user "bob", :path => "/developer/" do
   login_profile :password_reset_required=>true
+  # access_key :access_key_prohibited=>true
 
   groups(
     "Admin"
@@ -285,6 +289,7 @@ end
 
 user "bob", :path => "/developer/" do
   login_profile :password_reset_required=>true
+  # access_key :access_key_prohibited=>true
 
   groups(
     "Admin"
@@ -295,6 +300,7 @@ end
 
 user "mary", :path => "/staff/" do
   # login_profile :password_reset_required=>true
+  access_key :access_key_prohibited=>false
 
   groups(
     # no group

--- a/lib/miam/driver.rb
+++ b/lib/miam/driver.rb
@@ -114,6 +114,22 @@ class Miam::Driver
     end
   end
 
+  def delete_access_key(user_name, access_key_ids)
+    log(:info, "Update User `#{user_name}`", :color => :green)
+    access_key_ids.map do |access_key_id|
+      log(:info, "  delete access key `#{access_key_id}`", :color => :green)
+    end
+
+    unless_dry_run do
+      access_key_ids.map do |access_key_id|
+        @iam.delete_access_key({
+          :access_key_id=> access_key_id,
+          :user_name=> user_name
+        })
+      end
+    end
+  end
+
   def add_user_to_groups(user_name, group_names)
     log(:info, "Update User `#{user_name}`", :color => :green)
     log(:info, "  add groups=#{group_names.join(',')}", :color => :green)

--- a/lib/miam/dsl/context/user.rb
+++ b/lib/miam/dsl/context/user.rb
@@ -16,6 +16,10 @@ class Miam::DSL::Context::User
     @result[:login_profile] = value
   end
 
+  def access_key(value)
+    @result[:access_key] = value
+  end
+
   def groups(*grps)
     @result[:groups].concat(grps.map(&:to_s))
   end

--- a/lib/miam/dsl/converter.rb
+++ b/lib/miam/dsl/converter.rb
@@ -34,6 +34,8 @@ class Miam::DSL::Converter
 user #{user_name.inspect}, #{Miam::Utils.unbrace(user_options.inspect)} do
   #{output_login_profile(attrs[:login_profile])}
 
+  #{output_access_key(attrs[:access_key])}
+
   #{output_user_groups(attrs[:groups])}
 
   #{output_policies(attrs[:policies])}
@@ -59,6 +61,14 @@ end
       "login_profile #{Miam::Utils.unbrace(login_profile.inspect)}"
     else
       '# login_profile :password_reset_required=>true'
+    end
+  end
+
+  def output_access_key(access_key)
+    if access_key[:access_key_id].length.positive?
+      'access_key :access_key_prohibited=>false'
+    else
+      '# access_key :access_key_prohibited=>true'
     end
   end
 


### PR DESCRIPTION
I want to manage users could have Access keys or not. (like #48)

 - `access_key :access_key_prohibited=>true` statement to delete existing Access keys and don't create when create user.
 - `access_key :access_key_prohibited=>false` statement or not existing, nothing changes operation.

Please give me an opinion and consideration.