### PR TITLE
Reorder Hash keys for trust policy comparison

### DIFF
--- a/lib/miam/ext/hash_ext.rb
+++ b/lib/miam/ext/hash_ext.rb
@@ -15,8 +15,8 @@ class Hash
     when Hash
       new_value = {}
 
-      value.each do |k, v|
-        new_value[k] = sort_array0(v)
+      value.keys.sort.each do |k|
+        new_value[k] = sort_array0(value.fetch(k))
       end
 
       new_value

--- a/spec/miam/hash_ext_spec.rb
+++ b/spec/miam/hash_ext_spec.rb
@@ -36,4 +36,71 @@ describe 'Hash#sort_array!' do
   subject { hash.sort_array! }
 
   it { is_expected.to eq expected_hash }
+
+  context 'on trust policy' do
+    let(:expected_trust_policy) do
+      {
+	'Version' => '2012-10-17',
+	'Statement' => [
+          {
+            'Action' => 'sts:AssumeRole',
+            'Effect' => 'Allow',
+            'Principal' => {
+              'AWS' => 'arn:aws:iam::111122223333:role/Role1',
+            },
+            'Sid' => 'sid1',
+          },
+          {
+            'Effect' => 'Allow',
+            'Principal' => {
+              'Federated' => 'arn:aws:iam::111122223333:oidc-provider/oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE',
+            },
+            'Action' => 'sts:AssumeRoleWithWebIdentity',
+            'Condition' => {
+              'StringEquals' => {
+                'oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub' => 'system:serviceaccount:default:miam',
+                'oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud' => 'sts.amazonaws.com',
+              },
+            },
+          },
+        ],
+      }
+    end
+
+    let(:actual_trust_policy) do
+      {
+        'Version' => '2012-10-17',
+        'Statement' => [
+          {
+            # Only the order of key-value pairs below are different
+            'Sid' => 'sid1',
+            'Effect' => 'Allow',
+            'Principal' => {
+              'AWS' => 'arn:aws:iam::111122223333:role/Role1',
+            },
+            'Action' => 'sts:AssumeRole',
+          },
+          {
+            'Effect' => 'Allow',
+            'Principal' => {
+              'Federated' => 'arn:aws:iam::111122223333:oidc-provider/oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE',
+            },
+            'Action' => 'sts:AssumeRoleWithWebIdentity',
+            'Condition' => {
+              'StringEquals' => {
+                'oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub' => 'system:serviceaccount:default:miam',
+                'oidc.eks.ap-northeast-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud' => 'sts.amazonaws.com',
+              },
+            },
+          },
+        ],
+      }
+    end
+
+    it 'ignores the order of Hash entries' do
+      expected_trust_policy.sort_array!
+      actual_trust_policy.sort_array!
+      expect(expected_trust_policy).to eq(actual_trust_policy)
+    end
+  end
 end


### PR DESCRIPTION
Reordering Hash keys is needed in some cases because Miam reorders Arrays by `to_s`.
https://github.com/codenize-tools/miam/blob/v0.2.5.beta1/lib/miam/ext/hash_ext.rb#L24
I attached real-world example as a test case that produces wrong difference.